### PR TITLE
use a source for flags that supports https

### DIFF
--- a/mb_COLLECTION-HIGHLIGHTER.user.js
+++ b/mb_COLLECTION-HIGHLIGHTER.user.js
@@ -401,7 +401,7 @@ function fetchReleasesStuff(pi) {
 						cou = cou[0].textContent;
 					}
 					if (typeof cou == "string" && cou.length == 2 && (cou.charAt(0) != "X" || cou == "XE")) {
-						frg.appendChild(createTag("img", {a: {alt: cou, src: "http://i.hbtronix.de/flags/" + (cou == "XE" ? "europeanunion" : cou.toLowerCase()) + ".png"}}));
+						frg.appendChild(createTag("img", {a: {alt: cou, src: "//raw.githubusercontent.com/stevenrskelton/flag-icon/master/png/16/country-4x3/" + (cou == "XE" ? "europeanunion" : cou.toLowerCase()) + ".png"}}));
 						frg.appendChild(document.createTextNode(" "));
 					}
 					modal(true, concat([

--- a/mb_COLLECTION-HIGHLIGHTER.user.js
+++ b/mb_COLLECTION-HIGHLIGHTER.user.js
@@ -401,7 +401,7 @@ function fetchReleasesStuff(pi) {
 						cou = cou[0].textContent;
 					}
 					if (typeof cou == "string" && cou.length == 2 && (cou.charAt(0) != "X" || cou == "XE")) {
-						frg.appendChild(createTag("img", {a: {alt: cou, src: "//raw.githubusercontent.com/stevenrskelton/flag-icon/master/png/16/country-4x3/" + (cou == "XE" ? "europeanunion" : cou.toLowerCase()) + ".png"}}));
+						frg.appendChild(createTag("img", {a: {alt: cou, src: "//raw.githubusercontent.com/markjames/famfamfam-flag-icons/master/icons/png/" + (cou == "XE" ? "europeanunion" : cou.toLowerCase()) + ".png"}}));
 						frg.appendChild(document.createTextNode(" "));
 					}
 					modal(true, concat([


### PR DESCRIPTION
Whenever I load my collection, the dev console gets flooded with warnings about loading insecure resources. Turns out the source you're using for the flag images doesn't support https.

This pull request switches that up to use a github-based source which (obviously) supports https, though you might actually just want to host all of the flags in your own repo.