### PR TITLE
All entity types links

### DIFF
--- a/mb_ALL-LINKS.user.js
+++ b/mb_ALL-LINKS.user.js
@@ -316,7 +316,9 @@ j2css.insertRule("ul.external_links > li.defaultAutolink.disabled { text-decorat
 j2css.insertRule("ul.external_links.configure > li.defaultAutolink.disabled { display: list-item; }", 0);
 j2css.insertRule("ul.external_links.configure > li.defaultAutolink > input[type='checkbox'] { display: inline; }", 0);
 var hrStyle = {css: ""};
+var firstRun = true;
 main();
+firstRun = false;
 for (var s = 0; s < document.styleSheets.length; s++) {
 	for (var r = 0; r < document.styleSheets[s].cssRules.length - 1; r++) {
 		if (hrStyle.match = document.styleSheets[s].cssRules[r].cssText.match(/(#sidebar.+ul.+hr) {(.+)}/)) {
@@ -380,7 +382,7 @@ function main() {
 				xhr.send(null);
 			}
 		}
-		if (entityType && entityNameNode && entityMBID && entityType == "artist") {
+		if (firstRun && entityType && entityNameNode && entityMBID && entityType == "artist") {
 			var artistid = entityMBID, artistname = entityNameNode;
 			var artistsortname, artistsortnameSwapped = "";
 			artistsortname = artistname.getAttribute("title");

--- a/mb_ALL-LINKS.user.js
+++ b/mb_ALL-LINKS.user.js
@@ -18,14 +18,65 @@
 // @icon         data:image/gif;base64,R0lGODlhEAAQAMIDAAAAAIAAAP8AAP///////////////////yH5BAEKAAQALAAAAAAQABAAAAMuSLrc/jA+QBUFM2iqA2ZAMAiCNpafFZAs64Fr66aqjGbtC4WkHoU+SUVCLBohCQA7
 // @require      https://greasyfork.org/scripts/10888-super/code/SUPER.js?version=125133&v=2016.5.11
 // @grant        none
+// @include      http*://*mbsandbox.org/area/*
+// @include      http*://*mbsandbox.org/artist/*
+// @include      http*://*mbsandbox.org/event/*
+// @include      http*://*mbsandbox.org/instrument/*
+// @include      http*://*mbsandbox.org/label/*
+// @include      http*://*mbsandbox.org/place/*
+// @include      http*://*mbsandbox.org/recording/*
+// @include      http*://*mbsandbox.org/release/*
+// @include      http*://*mbsandbox.org/release-group/*
+// @include      http*://*mbsandbox.org/series/*
+// @include      http*://*mbsandbox.org/url/*
+// @include      http*://*mbsandbox.org/work/*
+// @include      http*://*musicbrainz.org/area/*
 // @include      http*://*musicbrainz.org/artist/*
+// @include      http*://*musicbrainz.org/event/*
+// @include      http*://*musicbrainz.org/instrument/*
+// @include      http*://*musicbrainz.org/label/*
+// @include      http*://*musicbrainz.org/place/*
+// @include      http*://*musicbrainz.org/recording/*
 // @include      http*://*musicbrainz.org/release/*
-// @include      http://*.mbsandbox.org/artist/*
+// @include      http*://*musicbrainz.org/release-group/*
+// @include      http*://*musicbrainz.org/series/*
+// @include      http*://*musicbrainz.org/url/*
+// @include      http*://*musicbrainz.org/work/*
 // @include      http://*.mbsandbox.org/release/*
 // @exclude      *//*/*mbsandbox.org/*
 // @exclude      *//*/*musicbrainz.org/*
-// @exclude      *//*musicbrainz.org/artist/*/edit
-// @exclude      *//*musicbrainz.org/artist/*/split
+// @exclude      *//*mbsandbox.org/*/*add*
+// @exclude      *//*mbsandbox.org/*/*annotat*
+// @exclude      *//*mbsandbox.org/*/*create*
+// @exclude      *//*mbsandbox.org/*/*delete*
+// @exclude      *//*mbsandbox.org/*/*edit*
+// @exclude      *//*mbsandbox.org/*/*merge*
+// @exclude      *//*mbsandbox.org/*/*remove*
+// @exclude      *//*mbsandbox.org/*/*split*
+// @exclude      *//*mbsandbox.org/*/*/*add*
+// @exclude      *//*mbsandbox.org/*/*/*annotat*
+// @exclude      *//*mbsandbox.org/*/*/*create*
+// @exclude      *//*mbsandbox.org/*/*/*delete*
+// @exclude      *//*mbsandbox.org/*/*/*edit*
+// @exclude      *//*mbsandbox.org/*/*/*merge*
+// @exclude      *//*mbsandbox.org/*/*/*remove*
+// @exclude      *//*mbsandbox.org/*/*/*split*
+// @exclude      *//*musicbrainz.org/*/*add*
+// @exclude      *//*musicbrainz.org/*/*annotat*
+// @exclude      *//*musicbrainz.org/*/*create*
+// @exclude      *//*musicbrainz.org/*/*delete*
+// @exclude      *//*musicbrainz.org/*/*edit*
+// @exclude      *//*musicbrainz.org/*/*merge*
+// @exclude      *//*musicbrainz.org/*/*remove*
+// @exclude      *//*musicbrainz.org/*/*split*
+// @exclude      *//*musicbrainz.org/*/*/*add*
+// @exclude      *//*musicbrainz.org/*/*/*annotat*
+// @exclude      *//*musicbrainz.org/*/*/*create*
+// @exclude      *//*musicbrainz.org/*/*/*delete*
+// @exclude      *//*musicbrainz.org/*/*/*edit*
+// @exclude      *//*musicbrainz.org/*/*/*merge*
+// @exclude      *//*musicbrainz.org/*/*/*remove*
+// @exclude      *//*musicbrainz.org/*/*/*split*
 // @run-at       document-end
 // ==/UserScript==
 "use strict";
@@ -256,7 +307,7 @@ var favicons = {
 var favicontry = [];
 var guessOtherFavicons = true;
 var sidebar = document.getElementById("sidebar");
-var arelsws = "/ws/2/artist/%artist-id%?inc=url-rels";
+var entityUrlRelsWS = "/ws/2/%entity-type%/%entity-mbid%?inc=url-rels";
 var existingLinks, extlinks;
 document.head.appendChild(document.createElement("style")).setAttribute("type", "text/css");
 var j2css = document.styleSheets[document.styleSheets.length - 1];
@@ -278,21 +329,12 @@ if (hrStyle.css) {
 }
 function main() {
 	if (sidebar) {
-		var artistid = self.location.href.match(/(?:mbsandbox|musicbrainz)\.org\/artist\/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}).*/i);
-		var artistname = document.querySelector("div#content > div.artistheader > h1 a, div#content > div.artistheader > h1 span[href]"); /* for compatibilly with https://gist.github.com/jesus2099/4111760 */
-		var artistsortname, artistsortnameSwapped = "";
-		if (artistid && artistname) {
-			artistid = artistid[1];
-			arelsws = arelsws.replace(/%artist-id%/, artistid);
-			artistsortname = artistname.getAttribute("title");
-			var tmpsn = artistsortname.split(",");
-			for (var isn = tmpsn.length - 1; isn >= 0; isn--) {
-				artistsortnameSwapped += tmpsn[isn].trim();
-				if (isn != 0) {
-					artistsortnameSwapped += " ";
-				}
-			}
-			artistname = artistname.textContent.trim();
+		var entityMatch = self.location.href.match(/\/([a-z\-]*)\/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}).*/i);
+		var entityType = entityMatch[1], entityMBID = entityMatch[2];
+		var entityHeaderClass = (entityType == "release-group" ? "rg" : entityType) + "header";
+		var entityNameNode = document.querySelector("div#content > div." + entityHeaderClass + " > h1 a, div#content > div." + entityHeaderClass + " > h1 span[href]"); /* for compatibilly with https://gist.github.com/jesus2099/4111760 */
+		if (entityType && entityMBID) {
+			entityUrlRelsWS = entityUrlRelsWS.replace(/%entity-type%/, entityType).replace(/%entity-mbid%/, entityMBID);
 			extlinks = sidebar.getElementsByClassName("external_links");
 			if (extlinks && extlinks.length > 0) {
 				extlinks = extlinks[0];
@@ -334,8 +376,25 @@ function main() {
 						}
 					}
 				};
-				xhr.open("GET", arelsws, true);
+				xhr.open("GET", entityUrlRelsWS, true);
 				xhr.send(null);
+			}
+		}
+		if (entityType && entityNameNode && entityMBID && entityType == "artist") {
+			var artistid = entityMBID, artistname = entityNameNode;
+			var artistsortname, artistsortnameSwapped = "";
+			artistsortname = artistname.getAttribute("title");
+			var tmpsn = artistsortname.split(",");
+			for (var isn = tmpsn.length - 1; isn >= 0; isn--) {
+				artistsortnameSwapped += tmpsn[isn].trim();
+				if (isn != 0) {
+					artistsortnameSwapped += " ";
+				}
+			}
+			artistname = artistname.textContent.trim();
+			extlinks = sidebar.getElementsByClassName("external_links");
+			if (extlinks && extlinks.length > 0) {
+				extlinks = extlinks[0];
 				// Autolinks
 				extlinksOpacity = autolinksOpacity;
 				for (var defaultOrUser in autolinks) if (autolinks.hasOwnProperty(defaultOrUser)) {
@@ -604,7 +663,7 @@ function error(code, text) {
 		ldng.setAttribute("id", userjs + "-error");
 		ldng.style.setProperty("background", "pink");
 		ldng.replaceChild(document.createTextNode("Error " + code), ldng.firstChild);
-		ldng.appendChild(createTag("a", {a: {href: arelsws}}, "*"));
+		ldng.appendChild(createTag("a", {a: {href: entityUrlRelsWS}}, "*"));
 		ldng.appendChild(document.createTextNode(" in "));
 		ldng.appendChild(createTag("a", {a: {href: "http://userscripts-mirror.org/scripts/show/108889"}}, "all links"));
 		ldng.appendChild(document.createTextNode(" ("));

--- a/mb_ALL-LINKS.user.js
+++ b/mb_ALL-LINKS.user.js
@@ -584,54 +584,7 @@ function addExternalLink(parameters/*text, target, begin, end, sntarget, mbid, e
 				cb.checked = false;
 			}
 		}
-		var favurltest = (typeof parameters.target == "string") ? parameters.target : parameters.target.action;
-		var favclass = "no";
-		// MusicBrainz cached favicon CSS classes
-		var searchdomain = favurltest.match(/site:([^+]*)\+/);
-		var urldomain = searchdomain ? searchdomain[1] : favurltest.split("/")[2];
-		for (var classdomain in faviconClasses) if (faviconClasses.hasOwnProperty(classdomain)) {
-			if (urldomain.match(classdomain)) {
-				favclass = faviconClasses[classdomain];
-				break;
-			}
-		}
-		if (favclass != "no") {
-			li.classList.add(favclass + "-favicon");
-		} else {
-			// Static favicon URL dictionary
-			var favurlfound = false;
-			for (var part in favicons) if (favicons.hasOwnProperty(part)) {
-				if (favurltest.indexOf(part) != -1) {
-					favurlfound = favicons[part];
-					break;
-				}
-			}
-			if (!guessOtherFavicons && !favurlfound) {
-				li.classList.add("no-favicon");
-			} else {
-				// arbitrary /favicon.ico load try out
-				if (guessOtherFavicons && !favurlfound) {
-					favurlfound = favurltest.substr(0, favurltest.indexOf("/", 8)) + "/favicon.ico";
-				}
-				var ifit = favicontry.length;
-				favicontry[ifit] = new Image();
-				favicontry[ifit].addEventListener("error", function (event) {
-					this.li.classList.add("no-favicon");
-				});
-				favicontry[ifit].addEventListener("load", function (event) {
-					clearTimeout(this.to);
-					this.li.style.setProperty("background-image", "url(" + this.src + ")");
-					this.li.style.setProperty("background-size", "16px 16px");
-				});
-				favicontry[ifit].li = li;
-				favicontry[ifit].src = favurlfound;
-				favicontry[ifit].to = setTimeout(function() {
-					// don’t wait for more than 5 seconds
-					favicontry[ifit].src = "";
-					favicontry[ifit].li.classList.add("no-favicon");
-				}, 5000);
-			}
-		}
+		setFavicon(li, (typeof parameters.target == "string") ? parameters.target : parameters.target.action);
 	} else {
 		// This is a header
 		var li = createTag("li", {s: {fontWeight: "bold"}}, parameters.text);
@@ -652,6 +605,55 @@ function addExternalLink(parameters/*text, target, begin, end, sntarget, mbid, e
 		if (parameters.target) { extlinks.appendChild(li); }
 	}
 	return newLink;
+}
+function setFavicon(li, url) {
+	var favclass = "no";
+	// MusicBrainz cached favicon CSS classes
+	var searchdomain = url.match(/site:([^+]*)\+/);
+	var urldomain = searchdomain ? searchdomain[1] : url.split("/")[2];
+	for (var classdomain in faviconClasses) if (faviconClasses.hasOwnProperty(classdomain)) {
+		if (urldomain.match(classdomain)) {
+			favclass = faviconClasses[classdomain];
+			break;
+		}
+	}
+	if (favclass != "no") {
+		li.classList.add(favclass + "-favicon");
+	} else {
+		// Static favicon URL dictionary
+		var favurlfound = false;
+		for (var part in favicons) if (favicons.hasOwnProperty(part)) {
+			if (url.indexOf(part) != -1) {
+				favurlfound = favicons[part];
+				break;
+			}
+		}
+		if (!guessOtherFavicons && !favurlfound) {
+			li.classList.add("no-favicon");
+		} else {
+			// arbitrary /favicon.ico load try out
+			if (guessOtherFavicons && !favurlfound) {
+				favurlfound = url.substr(0, url.indexOf("/", 8)) + "/favicon.ico";
+			}
+			var ifit = favicontry.length;
+			favicontry[ifit] = new Image();
+			favicontry[ifit].addEventListener("error", function (event) {
+				this.li.classList.add("no-favicon");
+			});
+			favicontry[ifit].addEventListener("load", function (event) {
+				clearTimeout(this.to);
+				this.li.style.setProperty("background-image", "url(" + this.src + ")");
+				this.li.style.setProperty("background-size", "16px 16px");
+			});
+			favicontry[ifit].li = li;
+			favicontry[ifit].src = favurlfound;
+			favicontry[ifit].to = setTimeout(function() {
+				// don’t wait for more than 5 seconds
+				favicontry[ifit].src = "";
+				favicontry[ifit].li.classList.add("no-favicon");
+			}, 5000);
+		}
+	}
 }
 function weirdobg() {
 	var weirdo = userjs + (new Date().getTime());

--- a/mb_ALL-LINKS.user.js
+++ b/mb_ALL-LINKS.user.js
@@ -32,6 +32,7 @@
 /* hint for Opera 12 users allow opera:config#UserPrefs|Allowscripttolowerwindow and opera:config#UserPrefs|Allowscripttoraisewindow */
 var userjs = "jesus2099_all-links_";
 var nonLatinName = /[\u0384-\u1cf2\u1f00-\uffff]/; // U+2FA1D is currently out of js range
+var extlinksOpacity = "1";
 var autolinksOpacity = ".5";
 var rawLanguages = JSON.parse(localStorage.getItem(userjs + "languages")) || ["navigator", "musicbrainz"];
 // %artist-id% (MBID)
@@ -252,6 +253,7 @@ var favicons = {
 	"rakuten.co.jp": "//plaza.rakuten.co.jp/favicon.ico",
 	"yahoo.": "http://blogs.yahoo.co.jp/favicon.ico",
 };
+var favicontry = [];
 var guessOtherFavicons = true;
 var sidebar = document.getElementById("sidebar");
 var arelsws = "/ws/2/artist/%artist-id%?inc=url-rels";
@@ -325,39 +327,6 @@ function main() {
 									}
 								}
 							}
-							// Autolinks
-							extlinksOpacity = autolinksOpacity;
-							for (var defaultOrUser in autolinks) if (autolinks.hasOwnProperty(defaultOrUser)) {
-								haslinks = false;
-								for (var link in autolinks[defaultOrUser]) if (autolinks[defaultOrUser].hasOwnProperty(link)) {
-									var target = autolinks[defaultOrUser][link];
-									var sntarget = null;
-									if (target) {
-										if (typeof target == "string") {
-											target = target.replace(/%artist-id%/, artistid);
-											if (target.match(/%artist-name%/) && artistname != artistsortnameSwapped && artistname.match(nonLatinName)) {
-												sntarget = target.replace(/%artist-name%/, encodeURIComponent(artistsortnameSwapped));
-											}
-											target = target.replace(/%artist-name%/, encodeURIComponent(artistname));
-											target = target.replace(/%artist-family-name-first%/, encodeURIComponent(artistname.match(nonLatinName) ? artistname : artistsortname));
-										} else {
-											var aname = target.acceptCharset;
-											aname = aname && aname.match(/iso-8859/i) && artistname != artistsortnameSwapped && artistname.match(nonLatinName) ? artistsortnameSwapped : artistname;
-											for (var param in target.parameters) if (target.parameters.hasOwnProperty(param)) {
-												target.parameters[param] = target.parameters[param].replace(/%artist-id%/, artistid).replace(/%artist-name%/, aname).replace(/%artist-family-name-first%/, artistname.match(nonLatinName) ? artistname : artistsortname);
-											}
-										}
-									}
-									if (addExternalLink({text: link, target: target, sntarget: sntarget, enabledDefaultAutolink: enabledDefaultAutolinks[link]})) {
-										if (!haslinks) {
-											haslinks = true;
-											addExternalLink({text: " " + defaultOrUser.substr(0, 1).toUpperCase() + defaultOrUser.substr(1).toLowerCase() + " autolinks"});
-											extlinks.lastChild.previousSibling.appendChild(document.createTextNode(" "));
-											extlinks.lastChild.previousSibling.appendChild(createTag("div", {a: {class: "icon img"}, s: {backgroundImage: "url(/static/images/icons/cog.png)"}}, createTag("a", {a: {title: "configure " + defaultOrUser + " autolinks"}, s: {color: "transparent"}, e: {click: configureModule}}, "configure")));
-										}
-									}
-								}
-							}
 						} else if (this.status >= 400) {
 							var txt = this.responseText.match(/<error><text>(.+)<\/text><text>/);
 							txt = txt ? txt[1] : "";
@@ -367,6 +336,39 @@ function main() {
 				};
 				xhr.open("GET", arelsws, true);
 				xhr.send(null);
+				// Autolinks
+				extlinksOpacity = autolinksOpacity;
+				for (var defaultOrUser in autolinks) if (autolinks.hasOwnProperty(defaultOrUser)) {
+					var haslinks = false;
+					for (var link in autolinks[defaultOrUser]) if (autolinks[defaultOrUser].hasOwnProperty(link)) {
+						var target = autolinks[defaultOrUser][link];
+						var sntarget = null;
+						if (target) {
+							if (typeof target == "string") {
+								target = target.replace(/%artist-id%/, artistid);
+								if (target.match(/%artist-name%/) && artistname != artistsortnameSwapped && artistname.match(nonLatinName)) {
+									sntarget = target.replace(/%artist-name%/, encodeURIComponent(artistsortnameSwapped));
+								}
+								target = target.replace(/%artist-name%/, encodeURIComponent(artistname));
+								target = target.replace(/%artist-family-name-first%/, encodeURIComponent(artistname.match(nonLatinName) ? artistname : artistsortname));
+							} else {
+								var aname = target.acceptCharset;
+								aname = aname && aname.match(/iso-8859/i) && artistname != artistsortnameSwapped && artistname.match(nonLatinName) ? artistsortnameSwapped : artistname;
+								for (var param in target.parameters) if (target.parameters.hasOwnProperty(param)) {
+									target.parameters[param] = target.parameters[param].replace(/%artist-id%/, artistid).replace(/%artist-name%/, aname).replace(/%artist-family-name-first%/, artistname.match(nonLatinName) ? artistname : artistsortname);
+								}
+							}
+						}
+						if (addExternalLink({text: link, target: target, sntarget: sntarget, enabledDefaultAutolink: enabledDefaultAutolinks[link]})) {
+							if (!haslinks) {
+								haslinks = true;
+								addExternalLink({text: " " + defaultOrUser.substr(0, 1).toUpperCase() + defaultOrUser.substr(1).toLowerCase() + " autolinks"});
+								extlinks.lastChild.previousSibling.appendChild(document.createTextNode(" "));
+								extlinks.lastChild.previousSibling.appendChild(createTag("div", {a: {class: "icon img"}, s: {backgroundImage: "url(/static/images/icons/cog.png)"}}, createTag("a", {a: {title: "configure " + defaultOrUser + " autolinks"}, s: {color: "transparent"}, e: {click: configureModule}}, "configure")));
+							}
+						}
+					}
+				}
 			}
 		}/*artist*/
 		/*wikidata to wikipedia*/
@@ -412,8 +414,6 @@ function main() {
 		}
 	}
 }
-var favicontry = [];
-var extlinksOpacity = "1";
 function addExternalLink(parameters/*text, target, begin, end, sntarget, mbid, enabledDefaultAutolink*/) {
 	var newLink = true;
 	var lis = extlinks.getElementsByTagName("li");

--- a/mb_ALL-LINKS.user.js
+++ b/mb_ALL-LINKS.user.js
@@ -567,7 +567,7 @@ function addExternalLink(parameters/*text, target, begin, end, sntarget, mbid, e
 				favicontry[ifit].to = setTimeout(function() {
 					// don’t wait for more than 5 seconds
 					favicontry[ifit].src = "";
-					this.li.classList.add("no-favicon");
+					favicontry[ifit].li.classList.add("no-favicon");
 				}, 5000);
 			}
 		}

--- a/mb_ALL-LINKS.user.js
+++ b/mb_ALL-LINKS.user.js
@@ -276,10 +276,6 @@ if (hrStyle.css) {
 }
 function main() {
 	if (sidebar) {
-		var rgextrels = sidebar.querySelector("ul.external_links_2 > li");
-		if (rgextrels && (rgextrels = rgextrels.parentNode) && rgextrels.previousSibling.tagName == "UL") {
-			rgextrels.parentNode.insertBefore(createTag("h2", {}, "Release group external links"), rgextrels);
-		}
 		var artistid = self.location.href.match(/(?:mbsandbox|musicbrainz)\.org\/artist\/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}).*/i);
 		var artistname = document.querySelector("div#content > div.artistheader > h1 a, div#content > div.artistheader > h1 span[href]"); /* for compatibilly with https://gist.github.com/jesus2099/4111760 */
 		var artistsortname, artistsortnameSwapped = "";


### PR DESCRIPTION
Implement feature request #187: Enable mb ALL LINKS for all MB entities (except collections).
Collateral fixes include:
- Remove a bit of obsolete code, reduce global variables usage, fix favicon guess timeout function.
- Display autolinks whatever the status of hidden links web service request. Note that hidden links are incidentally displayed below autolinks.

Edit: separate commits make easier to distinguish code moves from other code changes.