### PR TITLE
Filter out non-element event targets in updateTags

### DIFF
--- a/mb_SUPER-MIND-CONTROL-II-X-TURBO.user.js
+++ b/mb_SUPER-MIND-CONTROL-II-X-TURBO.user.js
@@ -1025,7 +1025,7 @@ function updateTags(event) {
 			for (var t = 0; t < mytags.length; t++) {
 				ownifyTag(mytags[t].previousSibling);
 			}
-		} else if (event.target) {
+		} else if (event.target && event.target.nodeType === Node.ELEMENT_NODE) {
 			var newTag = event.target.querySelector("span.tag-upvoted") && event.target.querySelector("a[href^='/tag/']");
 			if (newTag) {
 				ownifyTag(newTag);


### PR DESCRIPTION
`event.target` can be a Text node, which doesn't have a `querySelector` method.

This throws an exception which gets logged quite a lot in MB's production Sentry instance. :)