### PR TITLE
Fix spot CAA for MBS v-2021-02-15

### DIFF
--- a/mb_SUPER-MIND-CONTROL-II-X-TURBO.user.js
+++ b/mb_SUPER-MIND-CONTROL-II-X-TURBO.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         mb. SUPER MIND CONTROL Ⅱ X TURBO
-// @version      2021.2.9
+// @version      2021.2.24
 // @description  musicbrainz.org power-ups: RELEASE_CLONER. copy/paste releases / DOUBLE_CLICK_SUBMIT / CONTROL_ENTER_SUBMIT / TRACKLIST_TOOLS. search→replace, track length parser, remove recording relationships, set selected works date / LAST_SEEN_EDIT. handy for subscribed entities / COOL_SEARCH_LINKS / COPY_TOC / ROW_HIGHLIGHTER / SPOT_CAA / SPOT_AC / RECORDING_LENGTH_COLUMN / RELEASE_EVENT_COLUMN / WARN_NEW_WINDOW / SERVER_SWITCH / TAG_TOOLS / USER_STATS / CHECK_ALL_SUBSCRIPTIONS / EASY_DATE. paste full dates in one go / STATIC_MENU / SLOW_DOWN_RETRY / CENTER_FLAGS / RATINGS_ON_TOP / HIDE_RATINGS / UNLINK_ENTITY_HEADER / MARK_PENDING_EDIT_MEDIUMS
 // @namespace    https://github.com/jesus2099/konami-command
 // @homepage     https://github.com/jesus2099/konami-command/blob/master/mb_SUPER-MIND-CONTROL-II-X-TURBO.md
@@ -654,7 +654,7 @@ if (j2sets.SPOT_AC) {
 j2setting("SPOT_CAA", true, true, "cover art archive’s images stand out from other images. Allows spotting incorrectly padded CAA uploads and looks cool altogether");
 j2setting("SPOT_CAA_css", "box-shadow: 0 0 8px black;", true, "CSS syntax (on “a.artwork-image > img”)");
 if (j2sets.SPOT_CAA) {
-	j2superturbo.addCSSRule("img[src*='//coverartarchive.org/'], img.uploader-preview-image { " + j2sets.SPOT_CAA_css + " }");
+	j2superturbo.addCSSRule("img[src*='//coverartarchive.org/'], img[src*='//archive.org/download/mbid-'], img.uploader-preview-image { " + j2sets.SPOT_CAA_css + " }");
 }
 // ================================================================= DISPLAY+
 // ## WARN_NEW_WINDOW ##


### PR DESCRIPTION
https://github.com/metabrainz/musicbrainz-server/pull/1886 changed how CAA images are loaded onto the page, loading directly from IA and bypassing the CAA redirect. This breaks `SPOT_CAA` of SUPER MIND CONTROL Ⅱ X TURBO, since it relies on `img`s with a CAA `src`.

The fix is simple: Amend the CSS rule to also match `img`s with an archive.org `src` that points to a CAA item (items starting with `mbid-` + the MB UUID).

I've also taken the liberty to already bump the version.