### PR TITLE
Hide more pointless stuff for PRINT ALL PAGES

### DIFF
--- a/mb_PRINT-ALL-PAGES.user.js
+++ b/mb_PRINT-ALL-PAGES.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         mb. PRINT ALL PAGES
-// @version      2021.3.9.107
+// @version      2021.3.9.1559
 // @description  musicbrainz.org: Print your complete collections to make your shopping lists or check lists. Maybe it will work on more than just collections, in the future.
 // @namespace    https://github.com/jesus2099/konami-command
 // @compatible   firefox(86.0)+violentmonkey(2.12.7)
@@ -65,8 +65,12 @@ function preparePage(event) {
 	css.print.insertRule("body > div:not(#page) { display: none; }", 0); // hide all except #page (#content, #sidebar)
 	css.print.insertRule("div#sidebar { display: none; }", 0); // hide #sidebar from #page
 	css.print.insertRule("div#content > :not(form):not(.collectionheader) { display: none; }", 0); // hide tabs and sub headers from #content
+	css.print.insertRule(".subheader > .small { display: none; }", 0); // hide "See all your collections" link
 	css.print.insertRule("div#content h2 ~ form[method='post'] > :not(table) { display: none; }", 0); // hide merge button from form
+	css.print.insertRule("th > a > span { display: none !important; }", 0); // hide inactive sort icons inside table column headers
 	css.print.insertRule("." + userjs.id + "toolbar { display: none; }", 0); // hide this script toolbar
+	css.print.insertRule("td > span.mp { background-color: initial !important; }", 0); // disable highlighting for pending edits
+	css.print.insertRule("a, a:visited { color: initial; }", 0); // display entity links without the usual blue highlighting
 	// hide columns from print:
 	// TODO: Add checkboxes in <thead> to let user say what columns to hide from print
 	// hide checkboxes


### PR DESCRIPTION
I already love the latest version of this userscript but I have found some more things which are pretty pointless to display in a printed document.

Hence I have added some additional rules to disable the highlighting for entities with pending edits and to hide the "See all your collections" link and the (inactive) sort icons inside table column headers (the active sort column still has its sort direction indicator if you have sorted your collection before printing).

In addition I have disabled the coloring of entity links and visited entity links as they are somewhat distracting IMO. The only case where this is potentially useful are artist credits where it differentiates artist names from join phrases - so in case you want to keep this "feature" I can withdraw this change. If there had been a suitable CSS selector for join phrases, I probably would have displayed them in italics.