### PR TITLE
mb_ALL-LINKS: Remove decoda

### DIFF
--- a/mb_ALL-LINKS.user.js
+++ b/mb_ALL-LINKS.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         mb. ALL LINKS
-// @version      2021.5.20
+// @version      2021.6.6
 // @changelog    https://github.com/jesus2099/konami-command/commits/master/mb_ALL-LINKS.user.js
 // @description  Hidden links include fanpage, social network, etc. (NO duplicates) Generated autolinks (configurable) includes plain web search, auto last.fm, Discogs and Genius searches, etc. Shows begin/end dates on URL and provides edit link. Expands Wikidata links to wikipedia articles.
 // @supportURL   https://github.com/jesus2099/konami-command/labels/mb_ALL-LINKS
@@ -117,7 +117,6 @@ var autolinks = {
 		"音楽の森（アーティスト）": "//www.minc.gr.jp/db/ArtNmSrch.aspx?ArtNm=%artist-name%",
 		"音楽の森（著作者）": "//www.minc.gr.jp/db/KenriSrch.aspx?KENRISYANM=%artist-family-name-first%",
 		"Lyrics": null,
-		"decoda": "http://decoda.com/search?q=%artist-name%",
 		"Genius": "//genius.com/search?q=%artist-name%",
 		"うたまっぷ（アーティスト）": {
 			acceptCharset: "euc-jp",


### PR DESCRIPTION
Decoda is pretty much defunct and also removed from MusicBrainz: https://tickets.metabrainz.org/browse/MBS-11288