### PR TITLE
Fix disabling J-Lyric search links

### DIFF
--- a/mb_ALL-LINKS.user.js
+++ b/mb_ALL-LINKS.user.js
@@ -340,11 +340,17 @@ var whitelistSearchLinks = {
 					"//genius.com/search?q=%recording-name%",
 					"//genius.com/search?q=%work-name%",
 				],
-				"J-Lyric（歌手名）": "//search2.j-lyric.net/index.php?ka=%artist-name%",
-				"J-Lyric（曲名）": [
-					"//search2.j-lyric.net/index.php?kt=%recording-name%",
-					"//search2.j-lyric.net/index.php?kt=%work-name%",
-				],
+				jlyricArtist: {
+					title: {ja: "J-Lyric（歌手名）"},
+					target: "//search2.j-lyric.net/index.php?ka=%artist-name%",
+				},
+				jlyricSong: {
+					title: {ja: "J-Lyric（曲名）"},
+					target: [
+						"//search2.j-lyric.net/index.php?kt=%recording-name%",
+						"//search2.j-lyric.net/index.php?kt=%work-name%",
+					],
+				},
 				Directlyrics: [
 					"//directlyrics.com/search?q=%artist-name%+inurl%3A-artist.html",
 					"//directlyrics.com/search?q=%work-name%+inurl%3A-lyrics.html"


### PR DESCRIPTION
# Problem

In `mb_ALL-LINKS`, it seems that key having kanji cannot be stored as disabled permanently.

# Solution

Using a key with ASCII characters for J-Lyric allows to disable it.

(This patch still keeps the title for J-Lyric search links.)

# Note

Pull request made intentionally against the branch I’m currently using.