### PR TITLE
Add BookBrainz search links

### DIFF
--- a/mb_ALL-LINKS.user.js
+++ b/mb_ALL-LINKS.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         mb. ALL LINKS
-// @version      2023.7.20
+// @version      2023.7.23
 // @description  Hidden links include fanpage, social network, etc. (NO duplicates) Generated autolinks (configurable) includes plain web search, auto last.fm, Discogs and lyrics searches, etc. Shows begin/end dates on URL and provides edit link. Expands Wikidata links to wikipedia articles.
 // @namespace    https://github.com/jesus2099/konami-command
 // @supportURL   https://github.com/jesus2099/konami-command/issues/488
@@ -533,6 +533,15 @@ var whitelistSearchLinks = {
 					"//www.whosampled.com/search/tracks/?q=%recording-name%",
 					"//www.whosampled.com/search/tracks/?q=%work-name%"
 				],
+				BookBrainz: [
+					"//bookbrainz.org/search?q=%artist-name%&type=author",
+					"//bookbrainz.org/search?q=%release-name%&type=edition",
+					"//bookbrainz.org/search?q=%release-group-name%&type=edition_group",
+					"//bookbrainz.org/search?q=%label-name%&type=publisher",
+					"//bookbrainz.org/search?q=%series-name%&type=series",
+					"//bookbrainz.org/search?q=%work-name%&type=work"
+				],
+				"BookBrainz (all entities)":  "//bookbrainz.org/search?q=%entity-name%&type=all_entities",
 				Wikidata: "//www.wikidata.org/w?search=%entity-name%",
 				Wikipedia: "//duckduckgo.com/?q=site:wikipedia.org+intitle%3A%22%entity-name%%22",
 				LocalWikipedia: {


### PR DESCRIPTION
This adds both entity type specific search links for the entities that map more or less 1:1 across MusicBrainz and BookBrainz as well as a generic search link for BB that will look in all entities.

I wasn’t sure of the positioning of these and also not sure if the generic BB search is warranted at all, but I included them for now.