### PR TITLE
Leave wiki links in annotations intact

### DIFF
--- a/mb_COLLECTION-HIGHLIGHTER.user.js
+++ b/mb_COLLECTION-HIGHLIGHTER.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         mb. COLLECTION HIGHLIGHTER
-// @version      2023.9.29
+// @version      2024.2.25
 // @description  musicbrainz.org: Highlights releases, release-groups, etc. that you have in your collections (anyone’s collection can be loaded) everywhere
 // @namespace    https://github.com/jesus2099/konami-command
 // @supportURL   https://github.com/jesus2099/konami-command/labels/mb_COLLECTION-HIGHLIGHTER
@@ -240,7 +240,7 @@ if (cat) {
 function findOwnedStuff() {
 	// Annotation link trim spaces and protocol + "//" + host
 	for (let annotationLinks = document.querySelectorAll("div#content div.annotation a, div#content div.annotation-preview a"), l = 0; l < annotationLinks.length; l++) {
-		annotationLinks[l].setAttribute("href", annotationLinks[l].getAttribute("href").trim().replace(/^((https?:)?\/\/(\w+\.)?musicbrainz\.org)\//, "/"));
+		annotationLinks[l].setAttribute("href", annotationLinks[l].getAttribute("href").trim().replace(/^((https?:)?\/\/((beta|test)\.)?musicbrainz\.org)\//, "/"));
 	}
 	for (let stu = 0; stu < collectedStuff.length; stu++) {
 		var cstuff = collectedStuff[stu];


### PR DESCRIPTION
Only strip MB main, beta and test domains from link href attributes.
Removing the domain for all subdomains broke wiki.musicbrainz.org links ([example](https://musicbrainz.org/recording/e7f77f7f-9eea-4c58-9934-0d29b5c9a2a4)).
Bug was introduced in 02d476a0b724f55162e6bb03e177a74abf38c095.